### PR TITLE
adds `peerDependencies` to `package-dts`

### DIFF
--- a/packages/package-dts/package.json
+++ b/packages/package-dts/package.json
@@ -71,6 +71,11 @@
     "fs-extra": "^10.0.0",
     "json-schema-to-typescript": "^10.1.5"
   },
+  "peerDependencies": {
+    "@types/bluebird": "*",
+    "@types/node": "*",
+    "ts-toolbelt": "*"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Resolves `yarn install` warning:

```
➤ YN0002: │ @ts-type/package-dts@npm:1.0.56 doesn't provide @types/bluebird (pf11ce), requested by ts-type
➤ YN0002: │ @ts-type/package-dts@npm:1.0.56 doesn't provide @types/node (pcb06f), requested by ts-type
➤ YN0002: │ @ts-type/package-dts@npm:1.0.56 doesn't provide ts-toolbelt (p34aa0), requested by ts-type
```

I presume these can be only peer dependencies, since the package doesn't crash. Presumably a consumer of this package already provides these as a dependency. If you feel different, like maybe `@types/bluebird` could be a versioned dependency or `ts-toolbelt` could be a dependency, then feel free to change this. I went for minimal viable change here.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>